### PR TITLE
Stavefeil i Rut

### DIFF
--- a/Tekst/08 Rut/004.md
+++ b/Tekst/08 Rut/004.md
@@ -3,7 +3,7 @@
 1 Men Boas var gått opp til byporten og hadde satt seg der. Da kom løseren som Boas hadde talt om, nettopp forbi, og Boas sa: Kom hit og sett deg her, min venn! Og han kom og satte seg.
 2 Så kalte han til seg ti menn av byens eldste og sa: Sett dere her! Og de satte seg.
 3 Deretter sa han til løseren: Den åker som tilhørte vår bror Elimelek, har No'omi solgt, hun som er kommet tilbake fra Moabs land.
-4 Og jeg tenkte jeg ville la dette komme til din kunnskap og si: Kjøp den i overvær av dem som sitter her, og av mitt folks eldste! Vil du innløse den, sa gjør det; men hvis ikke, så si meg det, sa jeg kan vite det! For det er ingen til å innløse den uten du og etter deg jeg selv. Han svarte: Jeg vil innløse den.
+4 Og jeg tenkte jeg ville la dette komme til din kunnskap og si: Kjøp den i overvær av dem som sitter her, og av mitt folks eldste! Vil du innløse den, så gjør det; men hvis ikke, så si meg det, så jeg kan vite det! For det er ingen til å innløse den uten du og etter deg jeg selv. Han svarte: Jeg vil innløse den.
 5 Da sa Boas: Når du kjøper åkeren av No'omi, kjøper du den også av moabittinnen Rut, den avdødes hustru, for å oppreise den avdødes navn på hans arvelodd.
 6 Løseren svarte: Jeg kan ikke innløse den for meg, for da ville jeg ødelegge min egen arvelodd; innløs du for deg det jeg skulle løse, for jeg kan ikke innløse det.
 7 I gamle dager var det skikk i Israel ved innløsning og bytte at den ene part til stadfestelse av saken dro sin sko av og gav den til den andre; dette gjaldt som bekreftelse i Israel.


### PR DESCRIPTION
Det sto "sa", men det skulle stå "så".

Jeg merket at akkurat denne feilen finnes det også på [bible gateway Ruth 4 DNB1930](https://www.biblegateway.com/passage/?search=ruth%204&version=DNB1930)

Har dette noe med feil ved maskininnlesninga tror du? I så fall kan det hende at vi har flere lignende feil i teksten?